### PR TITLE
Use clap to parse command line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/dtolnay/noisy-clippy"
 
 [dependencies]
 anyhow = "1.0"
+clap = { version = "4", features = ["deprecated", "derive"] }
 flate2 = "1.0"
 git2 = "0.16"
 parking_lot = "0.12"


### PR DESCRIPTION
This gives `cargo run -- --help` a not silly behavior.